### PR TITLE
migrate to analyzer 5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.4'
+          flutter-version: '3.3.5'
           channel: 'stable'
       - run: dart pub get
       - run: dart analyze

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pubspec.lock
 .log*
 example/pubspec.lock
 tools/analyzer_plugin/pubspec.lock
+.fvm/

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/src/lint/exhaustive_keys.dart
+++ b/lib/src/lint/exhaustive_keys.dart
@@ -397,7 +397,7 @@ class _LocalVariableVisitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final elem = decl.name.staticElement;
+    final elem = decl.declaredElement;
 
     if (elem is! LocalVariableElement) {
       log.finest(

--- a/lib/src/lint/hook_widget_visitor.dart
+++ b/lib/src/lint/hook_widget_visitor.dart
@@ -57,7 +57,7 @@ class _BuildVisitor<C> extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    if (node.name.name != 'build') return;
+    if (node.name.lexeme != 'build') return;
 
     log.finer('_BuildVisitor: visit($node)');
 
@@ -81,8 +81,8 @@ class CustomHookFunctionVisitor<C> extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    if (!node.name.name.startsWith('use') &&
-        !node.name.name.startsWith('_use')) {
+    if (!node.name.lexeme.startsWith('use') &&
+        !node.name.lexeme.startsWith('_use')) {
       return;
     }
 

--- a/lib/src/lint/rules_of_hooks.dart
+++ b/lib/src/lint/rules_of_hooks.dart
@@ -73,7 +73,7 @@ class _HooksInvocationVisitor extends RecursiveAstVisitor<void> {
     log.finest('_HooksInvocationVisitor: _findControlFlow($node)');
 
     if (node == null) return false;
-    if (node is MethodDeclaration && node.name.name == 'build') {
+    if (node is MethodDeclaration && node.name.lexeme == 'build') {
       return false;
     }
 

--- a/lib/src/plugin/plugin.dart
+++ b/lib/src/plugin/plugin.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/analysis/context_builder.dart';
-import 'package:analyzer/dart/analysis/context_locator.dart';
+import 'package:analyzer/dart/analysis/analysis_context.dart';
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer_plugin/plugin/plugin.dart';
-import 'package:analyzer/src/dart/analysis/driver_based_analysis_context.dart';
 import 'package:analyzer_plugin/protocol/protocol_generated.dart' as plugin;
 import 'package:flutter_hooks_lint_plugin/src/lint/config.dart';
 import 'package:flutter_hooks_lint_plugin/src/lint/exhaustive_keys.dart';
@@ -18,10 +16,12 @@ import 'package:glob/glob.dart';
 import 'package:yaml/yaml.dart';
 
 class FlutterHooksRulesPlugin extends ServerPlugin {
-  FlutterHooksRulesPlugin(ResourceProvider? provider) : super(provider);
+  FlutterHooksRulesPlugin({
+    required super.resourceProvider,
+  });
 
-  var _filesFromSetPriorityFilesRequest = <String>[];
-  Options options = Options();
+  AnalysisContextCollection? _contextCollection;
+  final _optionsMap = <String, Options>{};
 
   @override
   List<String> get fileGlobsToAnalyze => const ['**/*.dart'];
@@ -29,95 +29,82 @@ class FlutterHooksRulesPlugin extends ServerPlugin {
   @override
   String get name => 'flutter_hooks_lint_plugin';
 
-  // NOTE: set the same version as the server
-  //  @see https://github.com/dart-lang/sdk/blob/e916841bcc5687e5fea4221d9fdbee2ccc3e412e/pkg/analyzer_plugin/lib/plugin/plugin.dart#L405
+  // NOTE: set the protocol version we use
+  //  @see https://github.com/dart-lang/sdk/blob/60773b91352872e5b04d254e3aa084a28f403a89/pkg/analysis_server/lib/protocol/protocol_constants.dart#L11
   @override
-  String get version => '1.0.0-alpha.0';
+  String get version => '1.33.1';
 
   @override
-  AnalysisDriverGeneric createAnalysisDriver(plugin.ContextRoot contextRoot) {
-    final rootPath = contextRoot.root;
-    final locator =
-        ContextLocator(resourceProvider: resourceProvider).locateRoots(
-      includedPaths: [rootPath],
-      excludedPaths: [
-        ...contextRoot.exclude,
-      ],
-      optionsFile: contextRoot.optionsFile,
-    );
+  Future<void> afterNewContextCollection({
+    required AnalysisContextCollection contextCollection,
+  }) {
+    _contextCollection = contextCollection;
 
-    if (locator.isEmpty) {
-      final error = StateError('Unexpected empty context');
-      channel.sendNotification(plugin.PluginErrorParams(
-        true,
-        error.message,
-        error.stackTrace.toString(),
-      ).toNotification());
+    contextCollection.contexts.forEach(_createConfig);
 
-      throw error;
+    return super
+        .afterNewContextCollection(contextCollection: contextCollection);
+  }
+
+  void _createConfig(AnalysisContext analysisContext) {
+    final rootPath = analysisContext.contextRoot.root.path;
+    final file = analysisContext.contextRoot.optionsFile;
+
+    if (file != null && file.exists) {
+      final options = _loadOptions(file);
+
+      _optionsMap[rootPath] = options;
     }
+  }
 
-    final builder = ContextBuilder(
-      resourceProvider: resourceProvider,
-    );
+  Options _loadOptions(File? file) {
+    if (file == null) return Options();
 
-    final analysisContext = builder.createContext(contextRoot: locator.first);
-    final context = analysisContext as DriverBasedAnalysisContext;
-    final dartDriver = context.driver;
+    final yaml = loadYaml(file.readAsStringSync());
 
+    return Options.fromYaml(yaml);
+  }
+
+  @override
+  Future<void> analyzeFile({
+    required AnalysisContext analysisContext,
+    required String path,
+  }) async {
     try {
-      options = _loadOptions(context.contextRoot.optionsFile);
-    } catch (e, s) {
+      final resolvedUnit =
+          await analysisContext.currentSession.getResolvedUnit(path);
+
+      if (resolvedUnit is ResolvedUnitResult) {
+        _processResult(
+          analysisContext.contextRoot.root.path,
+          resolvedUnit,
+        );
+      } else {
+        channel.sendNotification(plugin.PluginErrorParams(
+          false,
+          'Failed to analyze ($resolvedUnit)',
+          '',
+        ).toNotification());
+      }
+    } on Exception catch (e, s) {
       channel.sendNotification(
         plugin.PluginErrorParams(
-          true,
-          'Failed to load options: ${e.toString()}',
+          false,
+          'Unexpected error: ${e.toString()}',
           s.toString(),
         ).toNotification(),
       );
     }
-
-    runZonedGuarded(
-      () {
-        dartDriver.results.listen((analysisResult) {
-          if (analysisResult is ResolvedUnitResult) {
-            _processResult(
-              dartDriver,
-              analysisResult,
-            );
-          } else if (analysisResult is ErrorsResult) {
-            channel.sendNotification(plugin.PluginErrorParams(
-              false,
-              'ErrorResult $analysisResult',
-              '',
-            ).toNotification());
-          }
-        });
-      },
-      (Object e, StackTrace stackTrace) {
-        channel.sendNotification(
-          plugin.PluginErrorParams(
-            false,
-            'Unexpected error: ${e.toString()}',
-            stackTrace.toString(),
-          ).toNotification(),
-        );
-      },
-    );
-
-    return dartDriver;
   }
 
-  List<Glob>? _excludeGlobs;
-  final Cache<String, bool> _excludeCache = Cache(5000);
-
   void _processResult(
-    AnalysisDriver dartDriver,
+    String rootPath,
     ResolvedUnitResult analysisResult,
   ) {
+    final options = _optionsMap[rootPath];
     final path = analysisResult.path;
 
-    _excludeGlobs ??= options.analyzer.exclude.map((e) => Glob(e)).toList();
+    _excludeGlobs ??= options?.analyzer.exclude.map((e) => Glob(e)).toList();
 
     final excluded = _excludeCache.doCache(
       path,
@@ -126,44 +113,41 @@ class FlutterHooksRulesPlugin extends ServerPlugin {
 
     if (excluded) return;
 
-    try {
-      final errors = _check(
-        dartDriver,
-        path,
-        analysisResult,
-      );
+    final errors = _check(
+      rootPath,
+      path,
+      analysisResult,
+    );
 
-      channel.sendNotification(
-        plugin.AnalysisErrorsParams(
-          path,
-          errors.map((e) => e.error).toList(),
-        ).toNotification(),
-      );
-    } catch (e, stackTrace) {
-      channel.sendNotification(
-        plugin.PluginErrorParams(
-          false,
-          e.toString(),
-          stackTrace.toString(),
-        ).toNotification(),
-      );
-    }
+    channel.sendNotification(
+      plugin.AnalysisErrorsParams(
+        path,
+        errors.map((e) => e.error).toList(),
+      ).toNotification(),
+    );
   }
+
+  List<Glob>? _excludeGlobs;
+  final Cache<String, bool> _excludeCache = Cache(5000);
 
   @override
   Future<plugin.EditGetFixesResult> handleEditGetFixes(
     plugin.EditGetFixesParams parameters,
   ) async {
     try {
-      final dartDriver = driverForPath(parameters.file) as AnalysisDriver;
-      // ignore: deprecated_member_use
-      final analysisResult = await dartDriver.getResult2(parameters.file);
+      final analysisContext = _contextCollection?.contextFor(parameters.file);
+      final analysisResult = await analysisContext?.currentSession
+          .getResolvedUnit(parameters.file);
 
-      if (analysisResult is! ResolvedUnitResult) {
+      if (analysisContext == null || analysisResult is! ResolvedUnitResult) {
         return plugin.EditGetFixesResult([]);
       }
 
-      final errors = _check(dartDriver, parameters.file, analysisResult)
+      final errors = _check(
+        analysisContext.contextRoot.root.path,
+        parameters.file,
+        analysisResult,
+      )
           .where(
             (fix) =>
                 fix.error.location.file == parameters.file &&
@@ -186,10 +170,11 @@ class FlutterHooksRulesPlugin extends ServerPlugin {
   }
 
   List<plugin.AnalysisErrorFixes> _check(
-    AnalysisDriver driver,
+    String rootPath,
     String filePath,
     ResolvedUnitResult analysisResult,
   ) {
+    final options = _optionsMap[rootPath];
     final errors = <plugin.AnalysisErrorFixes>[];
 
     final supression = Suppression(
@@ -209,7 +194,8 @@ class FlutterHooksRulesPlugin extends ServerPlugin {
 
     findExhaustiveKeys(
       analysisResult.unit,
-      options: options.flutterHooksLintPlugin.exhaustiveKeys,
+      options: options?.flutterHooksLintPlugin.exhaustiveKeys ??
+          ExhaustiveKeysOptions(),
       onReport: onReport,
     );
 
@@ -219,61 +205,5 @@ class FlutterHooksRulesPlugin extends ServerPlugin {
     );
 
     return errors;
-  }
-
-  Options _loadOptions(File? file) {
-    if (file == null) return Options();
-
-    final yaml = loadYaml(file.readAsStringSync());
-
-    return Options.fromYaml(yaml);
-  }
-
-  // from https://github.com/dart-code-checker/dart-code-metrics/blob/e8e14d44b940a5b29d33a782432f853ee42ac7a0/lib/src/analyzer_plugin/analyzer_plugin.dart#L274
-  @override
-  void contentChanged(String path) {
-    super.driverForPath(path)?.addFile(path);
-  }
-
-  @override
-  Future<plugin.AnalysisSetContextRootsResult> handleAnalysisSetContextRoots(
-    plugin.AnalysisSetContextRootsParams parameters,
-  ) async {
-    final result = await super.handleAnalysisSetContextRoots(parameters);
-    _updatePriorityFiles();
-
-    return result;
-  }
-
-  @override
-  Future<plugin.AnalysisSetPriorityFilesResult> handleAnalysisSetPriorityFiles(
-    plugin.AnalysisSetPriorityFilesParams parameters,
-  ) async {
-    _filesFromSetPriorityFilesRequest = parameters.files;
-    _updatePriorityFiles();
-
-    return plugin.AnalysisSetPriorityFilesResult();
-  }
-
-  void _updatePriorityFiles() {
-    final filesToFullyResolve = {
-      ..._filesFromSetPriorityFilesRequest,
-      for (final driver2 in driverMap.values)
-        ...(driver2 as AnalysisDriver).addedFiles,
-    };
-
-    final filesByDriver = <AnalysisDriverGeneric, List<String>>{};
-    for (final file in filesToFullyResolve) {
-      final contextRoot = contextRootContaining(file);
-      if (contextRoot != null) {
-        final driver = driverMap[contextRoot];
-        if (driver != null) {
-          filesByDriver.putIfAbsent(driver, () => <String>[]).add(file);
-        }
-      }
-    }
-    filesByDriver.forEach((driver, files) {
-      driver.priorityFiles = files;
-    });
   }
 }

--- a/lib/src/plugin/starter.dart
+++ b/lib/src/plugin/starter.dart
@@ -6,6 +6,8 @@ import 'package:flutter_hooks_lint_plugin/src/plugin/plugin.dart';
 
 void start(Iterable<String> _, SendPort sendPort) {
   ServerPluginStarter(
-    FlutterHooksRulesPlugin(PhysicalResourceProvider.INSTANCE),
+    FlutterHooksRulesPlugin(
+      resourceProvider: PhysicalResourceProvider.INSTANCE,
+    ),
   ).start(sendPort);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ repository: https://github.com/mj-hd/flutter_hooks_lint_plugin
 version: 0.5.2
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
   flutter: ">=1.20.0"
 
 dependencies:
-  analyzer: ">=3.4.0 <5.0.0"
-  analyzer_plugin: ">=0.9.0 <=0.10.0"
+  analyzer: ">=5.1.0 <5.2.0"
+  analyzer_plugin: ">=0.11.0 <0.12.0"
   logging: ^1.0.0
   yaml: ^3.1.0
   path: ^1.8.0
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   flutter:
     sdk: flutter
-  lints: 2.0.0
+  lints: 2.0.1
   test: ^1.21.1
   tuple: ^2.0.0
   flutter_hooks: ^0.18.3

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -3,7 +3,7 @@ description: bootstrap package of flutter_hooks_lint_plugin
 version: 0.5.2
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   flutter_hooks_lint_plugin: ^0.5.2


### PR DESCRIPTION
This PR closes #25, and contains following changes:
- use new APIs instead of removed APIs
- use `AnalysisContextCollection` to manage contexts (ref: https://github.com/dart-code-checker/dart-code-metrics/pull/1020/commits/ae996cd6b75ff9c89f9d599cf1a8f9fd80b99df2)
- handle context's analyzer options properly
- bump minimum supported versions of `analyzer`, `analyzer_plugin` due to its breaking changes
- bump dart SDK to the newer one